### PR TITLE
Fix: Ensure DNI and telefono are trimmed before server-side validation

### DIFF
--- a/src/controllers/admin.controller.js
+++ b/src/controllers/admin.controller.js
@@ -14,14 +14,17 @@ const create = async (req, res) => {
 const store = async (req, res) => {
   const { username, password, nombre, apellido, dni, telefono, email } = req.body;
 
+  const trimmedDni = dni ? dni.trim() : '';
+  const trimmedTelefono = telefono ? telefono.trim() : '';
+
   // Server-side validation
-  if (dni && !/^\d{8}$/.test(dni)) {
+  if (trimmedDni && !/^\d{8}$/.test(trimmedDni)) {
     return res.render('admins/create', {
       error: 'El DNI debe tener 8 dígitos numéricos.',
       formData: req.body
     });
   }
-  if (telefono && telefono.trim() !== '' && !/^\d{9}$/.test(telefono)) {
+  if (trimmedTelefono && !/^\d{9}$/.test(trimmedTelefono)) {
     return res.render('admins/create', {
       error: 'El Teléfono debe tener 9 dígitos numéricos.',
       formData: req.body
@@ -30,7 +33,7 @@ const store = async (req, res) => {
 
   try {
     const userId = await model.createUser(username, password);
-    await model.createAdmin({ userId, nombre, apellido, dni, telefono, email });
+    await model.createAdmin({ userId, nombre, apellido, dni: trimmedDni, telefono: trimmedTelefono, email }); // Use trimmed versions
     res.redirect('/admins');
   } catch (error) {
     console.error("Error al crear admin:", error);
@@ -54,8 +57,11 @@ const update = async (req, res) => {
   const { nombre, apellido, dni, telefono, email } = req.body;
   const adminId = req.params.id;
 
+  const trimmedDni = dni ? dni.trim() : '';
+  const trimmedTelefono = telefono ? telefono.trim() : '';
+
   // Server-side validation
-  if (dni && !/^\d{8}$/.test(dni)) {
+  if (trimmedDni && !/^\d{8}$/.test(trimmedDni)) {
     const admin = await model.getById(adminId); // Fetch admin data for re-rendering
     return res.render('admins/edit', {
       error: 'El DNI debe tener 8 dígitos numéricos.',
@@ -63,7 +69,7 @@ const update = async (req, res) => {
       admin: admin
     });
   }
-  if (telefono && telefono.trim() !== '' && !/^\d{9}$/.test(telefono)) {
+  if (trimmedTelefono && !/^\d{9}$/.test(trimmedTelefono)) {
     const admin = await model.getById(adminId); // Fetch admin data for re-rendering
     return res.render('admins/edit', {
       error: 'El Teléfono debe tener 9 dígitos numéricos.',
@@ -72,7 +78,7 @@ const update = async (req, res) => {
     });
   }
 
-  await model.updateAdmin(adminId, { nombre, apellido, dni, telefono, email });
+  await model.updateAdmin(adminId, { nombre, apellido, dni: trimmedDni, telefono: trimmedTelefono, email }); // Use trimmed versions
   res.redirect('/admins');
 };
 

--- a/src/controllers/chofer.controller.js
+++ b/src/controllers/chofer.controller.js
@@ -8,14 +8,17 @@ const create = async (req, res) => {
 const store = async (req, res) => {
   const { username, password, nombre, apellido, dni, telefono, email } = req.body;
 
+  const trimmedDni = dni ? dni.trim() : '';
+  const trimmedTelefono = telefono ? telefono.trim() : '';
+
   // Server-side validation
-  if (dni && !/^\d{8}$/.test(dni)) {
+  if (trimmedDni && !/^\d{8}$/.test(trimmedDni)) {
     return res.render('choferes/create', {
       error: 'El DNI debe tener 8 dígitos numéricos.',
       formData: req.body
     });
   }
-  if (telefono && telefono.trim() !== '' && !/^\d{9}$/.test(telefono)) {
+  if (trimmedTelefono && !/^\d{9}$/.test(trimmedTelefono)) {
     return res.render('choferes/create', {
       error: 'El Teléfono debe tener 9 dígitos numéricos.',
       formData: req.body
@@ -24,7 +27,7 @@ const store = async (req, res) => {
 
   try {
     const userId = await model.createUser(username, password);
-    await model.createChofer({ userId, nombre, apellido, dni, telefono, email });
+    await model.createChofer({ userId, nombre, apellido, dni: trimmedDni, telefono: trimmedTelefono, email }); // Use trimmed versions
     res.redirect('/choferes');
   } catch (error) {
     console.error("Error al crear chofer:", error);
@@ -55,8 +58,11 @@ const update = async (req, res) => {
   const { nombre, apellido, dni, telefono, email } = req.body;
   const choferId = req.params.id;
 
+  const trimmedDni = dni ? dni.trim() : '';
+  const trimmedTelefono = telefono ? telefono.trim() : '';
+
   // Server-side validation
-  if (dni && !/^\d{8}$/.test(dni)) {
+  if (trimmedDni && !/^\d{8}$/.test(trimmedDni)) {
     const chofer = await model.getById(choferId);
     return res.render('choferes/edit', {
       error: 'El DNI debe tener 8 dígitos numéricos.',
@@ -64,7 +70,7 @@ const update = async (req, res) => {
       chofer: chofer
     });
   }
-  if (telefono && telefono.trim() !== '' && !/^\d{9}$/.test(telefono)) {
+  if (trimmedTelefono && !/^\d{9}$/.test(trimmedTelefono)) {
     const chofer = await model.getById(choferId);
     return res.render('choferes/edit', {
       error: 'El Teléfono debe tener 9 dígitos numéricos.',
@@ -73,7 +79,7 @@ const update = async (req, res) => {
     });
   }
 
-  await model.updateChofer(choferId, { nombre, apellido, dni, telefono, email });
+  await model.updateChofer(choferId, { nombre, apellido, dni: trimmedDni, telefono: trimmedTelefono, email }); // Use trimmed versions
   res.redirect('/choferes');
 };
 

--- a/src/controllers/cliente.controller.js
+++ b/src/controllers/cliente.controller.js
@@ -8,15 +8,18 @@ const create = (req, res) => {
 const store = async (req, res) => {
   const { nombre, apellido, dni, telefono, correo } = req.body; // 'correo' instead of 'email'
 
+  const trimmedDni = dni ? dni.trim() : '';
+  const trimmedTelefono = telefono ? telefono.trim() : '';
+
   // Server-side validation for DNI and Telefono format
-  if (dni && !/^\d{8}$/.test(dni)) {
+  if (trimmedDni && !/^\d{8}$/.test(trimmedDni)) {
     return res.render('clientes/create', {
       error: 'El DNI debe tener 8 dígitos numéricos.',
       formData: req.body
     });
   }
-  // Assuming 'telefono' can be optional or empty. If not, the condition telefono.trim() !== '' might need adjustment.
-  if (telefono && telefono.trim() !== '' && !/^\d{9}$/.test(telefono)) {
+
+  if (trimmedTelefono && !/^\d{9}$/.test(trimmedTelefono)) {
     return res.render('clientes/create', {
       error: 'El Teléfono debe tener 9 dígitos numéricos.',
       formData: req.body
@@ -24,7 +27,7 @@ const store = async (req, res) => {
   }
 
   try {
-    const dniExiste = await model.existsDNI(dni);
+    const dniExiste = await model.existsDNI(trimmedDni); // Use trimmedDni
 
     if (dniExiste) {
       return res.render("clientes/create", {
@@ -33,7 +36,7 @@ const store = async (req, res) => {
       });
     }
 
-    await model.store({ nombre, apellido, dni, telefono, correo }); // Use 'correo'
+    await model.store({ nombre, apellido, dni: trimmedDni, telefono: trimmedTelefono, correo }); // Use trimmed versions
     res.redirect("/clientes");
   } catch (error) {
     console.error("Error al guardar cliente:", error);
@@ -84,8 +87,11 @@ const update = async (req, res) => {
   const { id } = req.params;
   const { nombre, apellido, dni, telefono, correo } = req.body; // 'correo' instead of 'email'
 
+  const trimmedDni = dni ? dni.trim() : '';
+  const trimmedTelefono = telefono ? telefono.trim() : '';
+
   // Server-side validation for DNI and Telefono format
-  if (dni && !/^\d{8}$/.test(dni)) {
+  if (trimmedDni && !/^\d{8}$/.test(trimmedDni)) {
     const cliente = await model.getById(id);
     return res.render('clientes/edit', {
       error: 'El DNI debe tener 8 dígitos numéricos.',
@@ -93,7 +99,7 @@ const update = async (req, res) => {
       cliente: cliente
     });
   }
-  if (telefono && telefono.trim() !== '' && !/^\d{9}$/.test(telefono)) {
+  if (trimmedTelefono && !/^\d{9}$/.test(trimmedTelefono)) {
     const cliente = await model.getById(id);
     return res.render('clientes/edit', {
       error: 'El Teléfono debe tener 9 dígitos numéricos.',
@@ -105,7 +111,7 @@ const update = async (req, res) => {
   try {
     // Consider DNI uniqueness check here as well if DNI can be changed
     // For now, proceeding with update as per original structure after format validation
-    await model.updateCliente(id, { nombre, apellido, dni, telefono, correo }); // Use 'correo'
+    await model.updateCliente(id, { nombre, apellido, dni: trimmedDni, telefono: trimmedTelefono, correo }); // Use trimmed versions
     res.redirect("/clientes");
   } catch (error) {
     console.error("Error al actualizar cliente:", error);

--- a/src/controllers/gerente.controller.js
+++ b/src/controllers/gerente.controller.js
@@ -14,14 +14,17 @@ const create = async (req, res) => {
 const store = async (req, res) => {
   const { username, password, nombre, apellido, dni, telefono, email } = req.body;
 
+  const trimmedDni = dni ? dni.trim() : '';
+  const trimmedTelefono = telefono ? telefono.trim() : '';
+
   // Server-side validation
-  if (dni && !/^\d{8}$/.test(dni)) {
+  if (trimmedDni && !/^\d{8}$/.test(trimmedDni)) {
     return res.render('gerentes/create', {
       error: 'El DNI debe tener 8 dígitos numéricos.',
       formData: req.body
     });
   }
-  if (telefono && telefono.trim() !== '' && !/^\d{9}$/.test(telefono)) {
+  if (trimmedTelefono && !/^\d{9}$/.test(trimmedTelefono)) {
     return res.render('gerentes/create', {
       error: 'El Teléfono debe tener 9 dígitos numéricos.',
       formData: req.body
@@ -30,7 +33,7 @@ const store = async (req, res) => {
 
   try {
     const userId = await model.createUser(username, password);
-    await model.createGerente({ userId, nombre, apellido, dni, telefono, email });
+    await model.createGerente({ userId, nombre, apellido, dni: trimmedDni, telefono: trimmedTelefono, email }); // Use trimmed versions
     res.redirect('/gerentes');
   } catch (error) {
     console.error("Error al crear gerente:", error);
@@ -54,8 +57,11 @@ const update = async (req, res) => {
   const { nombre, apellido, dni, telefono, email } = req.body;
   const gerenteId = req.params.id;
 
+  const trimmedDni = dni ? dni.trim() : '';
+  const trimmedTelefono = telefono ? telefono.trim() : '';
+
   // Server-side validation
-  if (dni && !/^\d{8}$/.test(dni)) {
+  if (trimmedDni && !/^\d{8}$/.test(trimmedDni)) {
     const gerente = await model.getById(gerenteId);
     return res.render('gerentes/edit', {
       error: 'El DNI debe tener 8 dígitos numéricos.',
@@ -63,7 +69,7 @@ const update = async (req, res) => {
       gerente: gerente
     });
   }
-  if (telefono && telefono.trim() !== '' && !/^\d{9}$/.test(telefono)) {
+  if (trimmedTelefono && !/^\d{9}$/.test(trimmedTelefono)) {
     const gerente = await model.getById(gerenteId);
     return res.render('gerentes/edit', {
       error: 'El Teléfono debe tener 9 dígitos numéricos.',
@@ -72,7 +78,7 @@ const update = async (req, res) => {
     });
   }
 
-  await model.updateGerente(gerenteId, { nombre, apellido, dni, telefono, email });
+  await model.updateGerente(gerenteId, { nombre, apellido, dni: trimmedDni, telefono: trimmedTelefono, email }); // Use trimmed versions
   res.redirect('/gerentes');
 };
 


### PR DESCRIPTION
This commit addresses an issue where server-side validations for DNI and telefono fields were failing even for inputs that appeared to have the correct number of digits (8 for DNI, 9 for telefono).

The root cause was identified as potential leading or trailing whitespace in the input values, which caused the regular expression checks to fail. Additionally, for the telefono field, the original value (not the trimmed one) was being used for the regex test in some cases.

The following changes have been implemented in the `store` and `update` functions of `cliente.controller.js`, `admin.controller.js`, `chofer.controller.js`, and `gerente.controller.js`:

- Input values for DNI and telefono are now explicitly trimmed using `.trim()` before any validation logic is applied.
- The trimmed values are used for both the regular expression validation and when passing the data to the respective model functions (e.g., `store`, `updateCliente`, `createAdmin`, `existsDNI`).
- The conditional check for telefono validation has been simplified, as the trimmed value inherently handles empty string cases correctly in conjunction with the logical AND.

These changes ensure that the validation logic is robust against whitespace issues and correctly validates the semantic content of the DNI and telefono fields.