### PR TITLE
Refactor: Temporarily remove server-side DNI/Telefono validation

### DIFF
--- a/src/controllers/admin.controller.js
+++ b/src/controllers/admin.controller.js
@@ -14,37 +14,16 @@ const create = async (req, res) => {
 const store = async (req, res) => {
   const { username, password, nombre, apellido, dni, telefono, email } = req.body;
 
-  // Process DNI
-  let processedDni = dni ? String(dni).trim() : '';
-  if (processedDni) {
-    processedDni = processedDni.replace(/\D/g, '');
-  }
+  // Basic trimming
+  const finalDni = dni ? String(dni).trim() : '';
+  const finalTelefono = telefono ? String(telefono).trim() : '';
 
-  // Process Telefono
-  let processedTelefono = telefono ? String(telefono).trim() : '';
-  if (processedTelefono) {
-    processedTelefono = processedTelefono.replace(/\D/g, '');
-  }
-
-  // DNI Validation (Assuming DNI is mandatory)
-  if (!processedDni || processedDni.length !== 8) {
-    return res.render('admins/create', {
-      error: 'El DNI debe tener 8 dígitos numéricos.',
-      formData: req.body
-    });
-  }
-
-  // Telefono Validation (Optional, but if provided, must be valid)
-  if (processedTelefono && processedTelefono.length !== 9) {
-    return res.render('admins/create', {
-      error: 'El Teléfono debe tener 9 dígitos numéricos.',
-      formData: req.body
-    });
-  }
+  // REMOVED DNI Validation block
+  // REMOVED Telefono Validation block
 
   try {
     const userId = await model.createUser(username, password);
-    await model.createAdmin({ userId, nombre, apellido, dni: processedDni, telefono: processedTelefono, email });
+    await model.createAdmin({ userId, nombre, apellido, dni: finalDni, telefono: finalTelefono, email });
     res.redirect('/admins');
   } catch (error) {
     console.error("Error al crear admin:", error);
@@ -68,39 +47,14 @@ const update = async (req, res) => {
   const { nombre, apellido, dni, telefono, email } = req.body;
   const adminId = req.params.id;
 
-  // Process DNI
-  let processedDni = dni ? String(dni).trim() : '';
-  if (processedDni) {
-    processedDni = processedDni.replace(/\D/g, '');
-  }
+  // Basic trimming
+  const finalDni = dni ? String(dni).trim() : '';
+  const finalTelefono = telefono ? String(telefono).trim() : '';
 
-  // Process Telefono
-  let processedTelefono = telefono ? String(telefono).trim() : '';
-  if (processedTelefono) {
-    processedTelefono = processedTelefono.replace(/\D/g, '');
-  }
+  // REMOVED DNI Validation block
+  // REMOVED Telefono Validation block
 
-  // DNI Validation (Assuming DNI is mandatory)
-  if (!processedDni || processedDni.length !== 8) {
-    const admin = await model.getById(adminId);
-    return res.render('admins/edit', {
-      error: 'El DNI debe tener 8 dígitos numéricos.',
-      formData: req.body,
-      admin: admin
-    });
-  }
-
-  // Telefono Validation (Optional, but if provided, must be valid)
-  if (processedTelefono && processedTelefono.length !== 9) {
-    const admin = await model.getById(adminId);
-    return res.render('admins/edit', {
-      error: 'El Teléfono debe tener 9 dígitos numéricos.',
-      formData: req.body,
-      admin: admin
-    });
-  }
-
-  await model.updateAdmin(adminId, { nombre, apellido, dni: processedDni, telefono: processedTelefono, email });
+  await model.updateAdmin(adminId, { nombre, apellido, dni: finalDni, telefono: finalTelefono, email });
   res.redirect('/admins');
 };
 

--- a/src/controllers/chofer.controller.js
+++ b/src/controllers/chofer.controller.js
@@ -8,37 +8,16 @@ const create = async (req, res) => {
 const store = async (req, res) => {
   const { username, password, nombre, apellido, dni, telefono, email } = req.body;
 
-  // Process DNI
-  let processedDni = dni ? String(dni).trim() : '';
-  if (processedDni) {
-    processedDni = processedDni.replace(/\D/g, '');
-  }
+  // Basic trimming
+  const finalDni = dni ? String(dni).trim() : '';
+  const finalTelefono = telefono ? String(telefono).trim() : '';
 
-  // Process Telefono
-  let processedTelefono = telefono ? String(telefono).trim() : '';
-  if (processedTelefono) {
-    processedTelefono = processedTelefono.replace(/\D/g, '');
-  }
-
-  // DNI Validation (Assuming DNI is mandatory)
-  if (!processedDni || processedDni.length !== 8) {
-    return res.render('choferes/create', {
-      error: 'El DNI debe tener 8 dígitos numéricos.',
-      formData: req.body
-    });
-  }
-
-  // Telefono Validation (Optional, but if provided, must be valid)
-  if (processedTelefono && processedTelefono.length !== 9) {
-    return res.render('choferes/create', {
-      error: 'El Teléfono debe tener 9 dígitos numéricos.',
-      formData: req.body
-    });
-  }
+  // REMOVED DNI Validation block
+  // REMOVED Telefono Validation block
 
   try {
     const userId = await model.createUser(username, password);
-    await model.createChofer({ userId, nombre, apellido, dni: processedDni, telefono: processedTelefono, email });
+    await model.createChofer({ userId, nombre, apellido, dni: finalDni, telefono: finalTelefono, email });
     res.redirect('/choferes');
   } catch (error) {
     console.error("Error al crear chofer:", error);
@@ -69,39 +48,14 @@ const update = async (req, res) => {
   const { nombre, apellido, dni, telefono, email } = req.body;
   const choferId = req.params.id;
 
-  // Process DNI
-  let processedDni = dni ? String(dni).trim() : '';
-  if (processedDni) {
-    processedDni = processedDni.replace(/\D/g, '');
-  }
+  // Basic trimming
+  const finalDni = dni ? String(dni).trim() : '';
+  const finalTelefono = telefono ? String(telefono).trim() : '';
 
-  // Process Telefono
-  let processedTelefono = telefono ? String(telefono).trim() : '';
-  if (processedTelefono) {
-    processedTelefono = processedTelefono.replace(/\D/g, '');
-  }
+  // REMOVED DNI Validation block
+  // REMOVED Telefono Validation block
 
-  // DNI Validation (Assuming DNI is mandatory)
-  if (!processedDni || processedDni.length !== 8) {
-    const chofer = await model.getById(choferId);
-    return res.render('choferes/edit', {
-      error: 'El DNI debe tener 8 dígitos numéricos.',
-      formData: req.body,
-      chofer: chofer
-    });
-  }
-
-  // Telefono Validation (Optional, but if provided, must be valid)
-  if (processedTelefono && processedTelefono.length !== 9) {
-    const chofer = await model.getById(choferId);
-    return res.render('choferes/edit', {
-      error: 'El Teléfono debe tener 9 dígitos numéricos.',
-      formData: req.body,
-      chofer: chofer
-    });
-  }
-
-  await model.updateChofer(choferId, { nombre, apellido, dni: processedDni, telefono: processedTelefono, email });
+  await model.updateChofer(choferId, { nombre, apellido, dni: finalDni, telefono: finalTelefono, email });
   res.redirect('/choferes');
 };
 

--- a/src/controllers/cliente.controller.js
+++ b/src/controllers/cliente.controller.js
@@ -8,46 +8,29 @@ const create = (req, res) => {
 const store = async (req, res) => {
   const { nombre, apellido, dni, telefono, correo } = req.body;
 
-  // Process DNI
-  let processedDni = dni ? String(dni).trim() : '';
-  if (processedDni) {
-    processedDni = processedDni.replace(/\D/g, '');
-  }
+  // Basic trimming (optional, but good practice)
+  const finalDni = dni ? String(dni).trim() : '';
+  const finalTelefono = telefono ? String(telefono).trim() : '';
 
-  // Process Telefono
-  let processedTelefono = telefono ? String(telefono).trim() : '';
-  if (processedTelefono) {
-    processedTelefono = processedTelefono.replace(/\D/g, '');
-  }
+  // REMOVED DNI Validation block:
+  // if (!finalDni || finalDni.length !== 8) { ... }
 
-  // DNI Validation (Assuming DNI is mandatory)
-  // Check if original dni was provided and if cleaned version has 8 digits
-  if (!processedDni || processedDni.length !== 8) {
-    return res.render('clientes/create', {
-      error: 'El DNI debe tener 8 dígitos numéricos.',
-      formData: req.body
-    });
-  }
-
-  // Telefono Validation (Optional, but if provided, must be valid)
-  if (processedTelefono && processedTelefono.length !== 9) {
-    return res.render('clientes/create', {
-      error: 'El Teléfono debe tener 9 dígitos numéricos.',
-      formData: req.body
-    });
-  }
+  // REMOVED Telefono Validation block:
+  // if (finalTelefono && finalTelefono.length !== 9) { ... }
 
   try {
-    const dniExiste = await model.existsDNI(processedDni); // Use processedDni
+    // Note: DNI existence check might still be relevant depending on requirements
+    // For now, keeping it as it's a data integrity check, not a format validation.
+    const dniExiste = await model.existsDNI(finalDni);
 
     if (dniExiste) {
       return res.render("clientes/create", {
-        error: "El DNI ya está registrado.",
+        error: "El DNI ya está registrado.", // This is a uniqueness constraint, not format.
         formData: req.body
       });
     }
 
-    await model.store({ nombre, apellido, dni: processedDni, telefono: processedTelefono, correo });
+    await model.store({ nombre, apellido, dni: finalDni, telefono: finalTelefono, correo });
     res.redirect("/clientes");
   } catch (error) {
     console.error("Error al guardar cliente:", error);
@@ -98,42 +81,18 @@ const update = async (req, res) => {
   const { id } = req.params;
   const { nombre, apellido, dni, telefono, correo } = req.body;
 
-  // Process DNI
-  let processedDni = dni ? String(dni).trim() : '';
-  if (processedDni) {
-    processedDni = processedDni.replace(/\D/g, '');
-  }
+  // Basic trimming
+  const finalDni = dni ? String(dni).trim() : '';
+  const finalTelefono = telefono ? String(telefono).trim() : '';
 
-  // Process Telefono
-  let processedTelefono = telefono ? String(telefono).trim() : '';
-  if (processedTelefono) {
-    processedTelefono = processedTelefono.replace(/\D/g, '');
-  }
+  // REMOVED DNI Validation block:
+  // if (!finalDni || finalDni.length !== 8) { ... }
 
-  // DNI Validation (Assuming DNI is mandatory)
-  if (!processedDni || processedDni.length !== 8) {
-    const cliente = await model.getById(id); // Fetch for re-rendering
-    return res.render('clientes/edit', {
-      error: 'El DNI debe tener 8 dígitos numéricos.',
-      formData: req.body,
-      cliente: cliente
-    });
-  }
-
-  // Telefono Validation (Optional, but if provided, must be valid)
-  if (processedTelefono && processedTelefono.length !== 9) {
-    const cliente = await model.getById(id); // Fetch for re-rendering
-    return res.render('clientes/edit', {
-      error: 'El Teléfono debe tener 9 dígitos numéricos.',
-      formData: req.body,
-      cliente: cliente
-    });
-  }
+  // REMOVED Telefono Validation block:
+  // if (finalTelefono && finalTelefono.length !== 9) { ... }
 
   try {
-    // Potentially check DNI uniqueness again if it can be changed and needs to be unique
-    // For now, focusing on format validation as per previous structure.
-    await model.updateCliente(id, { nombre, apellido, dni: processedDni, telefono: processedTelefono, correo });
+    await model.updateCliente(id, { nombre, apellido, dni: finalDni, telefono: finalTelefono, correo });
     res.redirect("/clientes");
   } catch (error) {
     console.error("Error al actualizar cliente:", error);

--- a/src/controllers/gerente.controller.js
+++ b/src/controllers/gerente.controller.js
@@ -14,37 +14,16 @@ const create = async (req, res) => {
 const store = async (req, res) => {
   const { username, password, nombre, apellido, dni, telefono, email } = req.body;
 
-  // Process DNI
-  let processedDni = dni ? String(dni).trim() : '';
-  if (processedDni) {
-    processedDni = processedDni.replace(/\D/g, '');
-  }
+  // Basic trimming
+  const finalDni = dni ? String(dni).trim() : '';
+  const finalTelefono = telefono ? String(telefono).trim() : '';
 
-  // Process Telefono
-  let processedTelefono = telefono ? String(telefono).trim() : '';
-  if (processedTelefono) {
-    processedTelefono = processedTelefono.replace(/\D/g, '');
-  }
-
-  // DNI Validation (Assuming DNI is mandatory)
-  if (!processedDni || processedDni.length !== 8) {
-    return res.render('gerentes/create', {
-      error: 'El DNI debe tener 8 dígitos numéricos.',
-      formData: req.body
-    });
-  }
-
-  // Telefono Validation (Optional, but if provided, must be valid)
-  if (processedTelefono && processedTelefono.length !== 9) {
-    return res.render('gerentes/create', {
-      error: 'El Teléfono debe tener 9 dígitos numéricos.',
-      formData: req.body
-    });
-  }
+  // REMOVED DNI Validation block
+  // REMOVED Telefono Validation block
 
   try {
     const userId = await model.createUser(username, password);
-    await model.createGerente({ userId, nombre, apellido, dni: processedDni, telefono: processedTelefono, email });
+    await model.createGerente({ userId, nombre, apellido, dni: finalDni, telefono: finalTelefono, email });
     res.redirect('/gerentes');
   } catch (error) {
     console.error("Error al crear gerente:", error);
@@ -68,39 +47,14 @@ const update = async (req, res) => {
   const { nombre, apellido, dni, telefono, email } = req.body;
   const gerenteId = req.params.id;
 
-  // Process DNI
-  let processedDni = dni ? String(dni).trim() : '';
-  if (processedDni) {
-    processedDni = processedDni.replace(/\D/g, '');
-  }
+  // Basic trimming
+  const finalDni = dni ? String(dni).trim() : '';
+  const finalTelefono = telefono ? String(telefono).trim() : '';
 
-  // Process Telefono
-  let processedTelefono = telefono ? String(telefono).trim() : '';
-  if (processedTelefono) {
-    processedTelefono = processedTelefono.replace(/\D/g, '');
-  }
+  // REMOVED DNI Validation block
+  // REMOVED Telefono Validation block
 
-  // DNI Validation (Assuming DNI is mandatory)
-  if (!processedDni || processedDni.length !== 8) {
-    const gerente = await model.getById(gerenteId);
-    return res.render('gerentes/edit', {
-      error: 'El DNI debe tener 8 dígitos numéricos.',
-      formData: req.body,
-      gerente: gerente
-    });
-  }
-
-  // Telefono Validation (Optional, but if provided, must be valid)
-  if (processedTelefono && processedTelefono.length !== 9) {
-    const gerente = await model.getById(gerenteId);
-    return res.render('gerentes/edit', {
-      error: 'El Teléfono debe tener 9 dígitos numéricos.',
-      formData: req.body,
-      gerente: gerente
-    });
-  }
-
-  await model.updateGerente(gerenteId, { nombre, apellido, dni: processedDni, telefono: processedTelefono, email });
+  await model.updateGerente(gerenteId, { nombre, apellido, dni: finalDni, telefono: finalTelefono, email });
   res.redirect('/gerentes');
 };
 


### PR DESCRIPTION
This commit removes server-side format and length validations for DNI and Telefono fields across all relevant controllers (`cliente`, `admin`, `chofer`, `gerente`) in their `store` and `update` methods.

This change is made at your request to temporarily disable these validations to allow for a re-evaluation of the validation strategy.

The following modifications were made in each controller:
- The `if` blocks responsible for checking DNI and Telefono length and/or format (e.g., regex checks or cleaned string length checks) have been removed.
- Complex input processing (like removing non-digit characters) associated with these validations has also been removed.
- A simple `String(value).trim()` is kept for basic input hygiene before passing the values to the models.
- In `cliente.controller.js`, the check for DNI uniqueness (`model.existsDNI`) was preserved as it pertains to data integrity rather than input format.

The application will now rely on client-side validation (if any) or database constraints for enforcing DNI and Telefono data rules until a new server-side validation approach is implemented.